### PR TITLE
Add requirements and install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There exist three dependencies:
 2. pyqt5
 3. Python3.6+
 
-To install `numpy` and `pyqt5`. This can be accomplished through pip: `pip3 install pyqt5 numpy`
+To install dependencies, run `pip3 install -r requirements.txt`
 
 ## Getting started
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pyqt5


### PR DESCRIPTION
Dependencies can easily be installed by adding them to a `requirements.txt` file and installing them with `pip3 install -r requirements.txt`.

This will make it easier to others to get up to speed.

This addresses some of the requests in #1 